### PR TITLE
Noop dead code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -200,6 +200,7 @@ macro_rules! test {
         #[test]
         $(#[$attr])*
         fn $name() {
+            #[allow(dead_code)]
             fn noop<F, R>(_: &::galvanic_test::FixtureBinding<F,R>) { }
             // Cell is a workaround for #![allow(unused_mut)] which would affect the whole fn
             let test_case_failed = ::std::cell::Cell::new(false);

--- a/tests/test_suite_no_mock.rs
+++ b/tests/test_suite_no_mock.rs
@@ -1,0 +1,76 @@
+/* Copyright 2017 Christopher Bacher
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#[macro_use] extern crate galvanic_test;
+
+test_suite! {
+    test simple_test_in_unnamed_test_suite() {
+        assert!(true);
+    }
+}
+
+test_suite! {
+    name named_test_suite0;
+
+    test simple_test() {
+        assert!(true);
+    }
+}
+
+test_suite! {
+    name named_test_suite1;
+
+    fixture test_fixture() -> i32 {
+        setup(&mut self) {
+            42
+        }
+    }
+
+    test inject_fixture(test_fixture) {
+        assert_eq!(test_fixture.val, 42);
+    }
+}
+
+test_suite! {
+    name named_test_suite2;
+
+    fixture fixture_with_params(x: i32, y: i32) -> i32 {
+        setup(&mut self) {
+            self.x * self.y
+        }
+    }
+
+    test inject_fixture(fixture_with_params(6, 7)) {
+        assert_eq!(fixture_with_params.val, 42);
+    }
+}
+
+test_suite! {
+    name parameterised_test_suite;
+
+    fixture fixture_with_params(x: i32, y: i32) -> i32 {
+        params {
+            vec![(1,2), (2,3), (3,4)].into_iter()
+        }
+        setup(&mut self) {
+            self.x * self.y
+        }
+    }
+
+    test inject_fixture(fixture_with_params) {
+        let params = &fixture_with_params.params;
+        assert_eq!(fixture_with_params.val, params.x*params.y);
+    }
+}


### PR DESCRIPTION
Fixes #5 

I don't know if this is the right way to fix the dead-code warning, but it doesn't generate any extra warnings and the crate tests still pass.

I added a new integration test for simple test suites without mock integration. You'll note that I left your name on the copyright notice at the top of the new file -- my intention is explicitly to have this file match all the others in the crate.

It might be worth creating `no_mock` versions of some of the other integration tests to help catch other possible corner-cases.