### PR TITLE
Rustc 1.31.0

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,7 +161,7 @@ macro_rules! test {
                 let mut $fixture_obj = $fixture::new(params);
                 described_params.push(format!("{:?}", $fixture_obj));
                 let mut $fixture = $fixture_obj.setup();
-                noop(&mut $fixture);
+                noop(&$fixture);
             )*
             described_parameters = described_params.join(", ");
             $body

--- a/tests/galvanic_mock_integration.rs
+++ b/tests/galvanic_mock_integration.rs
@@ -15,8 +15,7 @@
 
 #![cfg(feature = "galvanic_mock_integration")]
 
-#![feature(proc_macro)]
-#![feature(proc_macro_mod)]
+#![feature(proc_macro_hygiene)]
 #[macro_use] extern crate galvanic_test;
 extern crate galvanic_mock;use galvanic_mock::*;
 

--- a/tests/test_suite.rs
+++ b/tests/test_suite.rs
@@ -13,8 +13,7 @@
  * limitations under the License.
  */
 
-#![cfg_attr(feature = "galvanic_mock_integration", feature(proc_macro))]
-#![cfg_attr(feature = "galvanic_mock_integration", feature(proc_macro_mod))]
+#![cfg_attr(feature = "galvanic_mock_integration", feature(proc_macro_hygiene))]
 
 #[macro_use] extern crate galvanic_test;
 #[cfg(feature = "galvanic_mock_integration")] extern crate galvanic_mock;


### PR DESCRIPTION
Fix build on rustc nightly 1.31.0, and fix some Clippy warnings that pop up in consumer crates.