### PR TITLE
Fix the test_suite macro when macro_use is not used

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,6 +227,7 @@ macro_rules! test_suite {
     ( name $name:ident ; $($remainder:tt)* ) => {
         #[cfg(test)]
         mod $name {
+            use super::*;
             #[allow(unused_imports)] use ::galvanic_test::TestFixture;
             __test_suite_int!(@int $($remainder)*);
         }
@@ -236,6 +237,7 @@ macro_rules! test_suite {
     ( $($remainder:tt)* ) => {
         #[cfg(test)]
         mod __galvanic_test {
+            use super::*;
             #[allow(unused_imports)] use ::galvanic_test::TestFixture;
             __test_suite_int!(@int $($remainder)*);
         }

--- a/tests/no_macro_use.rs
+++ b/tests/no_macro_use.rs
@@ -1,0 +1,29 @@
+/* Copyright 2018 Alan Somers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! As of Rustc 1.30.0 the `test_suite` macro should be importable with `use`,
+//! rather than `macro_use`
+
+#![cfg_attr(feature = "galvanic_mock_integration", feature(proc_macro_hygiene))]
+#[cfg(feature = "galvanic_mock_integration")] extern crate galvanic_mock;
+extern crate galvanic_test;
+
+use galvanic_test::*;
+
+test_suite! {
+    test simple_test_in_unnamed_test_suite() {
+        assert!(true);
+    }
+}


### PR DESCRIPTION
As of rustc stable, 1.30.0 #[macro_use] should no longer be necessary.
Macros can now be imported with plain old `use`.  This commit fixes
`test_suite` so it can find the path to `__test_suite_int` when
macro_use is not in use.